### PR TITLE
Fix: remove '?' when handling punctuation removal

### DIFF
--- a/src/components/TextForm.js
+++ b/src/components/TextForm.js
@@ -20,7 +20,7 @@ export default function TextForm(props) {
   };
 
   const handlePunctuation = () => {
-    let newText = text.replace(/[.,\/#!?$%\^&\*;:{}=\-_`~()]/g, "");
+    let newText = text.replace(/[.,\/#!?$%\^\*;:{}=\-_`~()]/g, "");
     setText(newText.replace(/\s{2,}/g, " "));
     props.showAlert("Punctuation Removed!", "success");
   };

--- a/src/components/TextForm.js
+++ b/src/components/TextForm.js
@@ -20,7 +20,7 @@ export default function TextForm(props) {
   };
 
   const handlePunctuation = () => {
-    let newText = text.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "");
+    let newText = text.replace(/[.,\/#!?$%\^&\*;:{}=\-_`~()]/g, "");
     setText(newText.replace(/\s{2,}/g, " "));
     props.showAlert("Punctuation Removed!", "success");
   };


### PR DESCRIPTION
This MR fixes an issue #25 by adjusting a regex used for punctuation removal (adding question mark `?` to the list of special characters).